### PR TITLE
Signal that we are done writing, fix deadlock

### DIFF
--- a/crates/git-remote-helper/src/commands/push.rs
+++ b/crates/git-remote-helper/src/commands/push.rs
@@ -242,6 +242,9 @@ where
             trace!("bytes written: {:#?}", bytes_written);
         }
 
+        // Signal that we are done writing
+        drop(writer);
+
         trace!("finished writing pack");
 
 

--- a/crates/git-remote-icp/src/http/reqwest/remote.rs
+++ b/crates/git-remote-icp/src/http/reqwest/remote.rs
@@ -6,7 +6,6 @@ use crate::{http, http::reqwest::Remote};
 use candid::{Decode, Encode};
 use git_features::io::pipe;
 use git_repository as git;
-// https://github.com/Byron/gitoxide/pull/690
 use git::protocol::transport::client::http::PostBodyDataKind;
 use ic_agent::export::Principal;
 use ic_agent::Agent;


### PR DESCRIPTION
This was an oversight that for some reason wasn't an issue with the other commands or transports, but affected push for ICP.